### PR TITLE
fix event sdk

### DIFF
--- a/framework/events.go
+++ b/framework/events.go
@@ -39,8 +39,6 @@ func (f *Framework) WaitExceptEventOccurred(ctx context.Context, eventKind, objN
 			}
 			f.Log("watch event object %v", event.Object)
 			switch event.Type {
-			case watch.Error:
-				return ErrEvent
 			case watch.Deleted:
 				return ErrResDel
 			default:
@@ -48,7 +46,7 @@ func (f *Framework) WaitExceptEventOccurred(ctx context.Context, eventKind, objN
 				if !ok {
 					return ErrGetObj
 				}
-				f.Log("Event occurred message is %v \n", event.Message)
+				f.Log("Event occurred message is %s/%v \n", event.Type, event.Message)
 				if strings.Contains(event.Message, message) {
 					return nil
 				}


### PR DESCRIPTION
The previous event method `WaitExceptEventOccurred` would ignore the `Error` type event and just returned it. Actually, we may need to match the `msg` in the `Error` type event