### PR TITLE
fix: If the PodList contains extra Pods, the judgment will fail.

### DIFF
--- a/.github/workflows/lint-golang.yaml
+++ b/.github/workflows/lint-golang.yaml
@@ -212,7 +212,7 @@ jobs:
       # ============= upload coverage report
       - name: Upload to Codecov
         if: ${{ steps.unitest.outcome != 'failure' }}
-        uses: codecov/codecov-action@v3.1.4
+        uses: codecov/codecov-action@v4
         with:
           directory: './'
           files: 'coverage.out'

--- a/framework/deployment.go
+++ b/framework/deployment.go
@@ -270,7 +270,7 @@ func (f *Framework) RestartDeploymentPodUntilReady(deployName, namespace string,
 	if err != nil {
 		return err
 	}
-	_, err = f.DeletePodListUntilReady(podList, timeOut, opts...)
+	_, err = f.DeletePodListUntilReady(podList, int(*deployment.Spec.Replicas), timeOut, opts...)
 	if err != nil {
 		return err
 	}

--- a/framework/pod.go
+++ b/framework/pod.go
@@ -292,7 +292,7 @@ func (f *Framework) DeletePodListRepeatedly(label map[string]string, interval ti
 	}
 }
 
-func (f *Framework) DeletePodListUntilReady(podList *corev1.PodList, timeOut time.Duration, opts ...client.DeleteOption) (*corev1.PodList, error) {
+func (f *Framework) DeletePodListUntilReady(podList *corev1.PodList, expectedPodNum int, timeOut time.Duration, opts ...client.DeleteOption) (*corev1.PodList, error) {
 	if podList == nil {
 		return nil, ErrWrongInput
 	}
@@ -321,7 +321,7 @@ OUTER:
 			continue
 		}
 
-		if len(podListWithLabel.Items) != len(podList.Items) {
+		if len(podListWithLabel.Items) == 0 || len(podListWithLabel.Items) != expectedPodNum {
 			continue
 		}
 


### PR DESCRIPTION
DeletePodListUntilReady 函数传入了 podList 入参，但是当在删除 PodList 前获取到的 PodList 可能是包含了 terminal 状态的 Pod ，此时去对比重启前后的 Pod 数，那么就无法成功。因为 len(podListWithLabel.Items) 将一定不等于 len(podList.Items)
```
func (f *Framework) DeletePodListUntilReady(podList *corev1.PodList, timeOut time.Duration, opts ...client.DeleteOption) (*corev1.PodList, error) {
```

pod 删除处于 terminal 状态的持续时间是不可控的，虽然可以通过 优雅期强制删除，但是对于 spiderpool-controller 这类特殊的 Pod ，强制删除后，由于资源没有回收完全，新的 spiderpool-controller Pod  可能由于端口冲突等问题而重启，而重启后，spiderpool 的 CI 日志采集脚本会判定 Pod 重启过，而 CI 失败 

在 DeletePodListUntilReady 中，增加 expectedPodNum 字段，用于判断你所需要的 Pod 数量，不再去通过传入的 len（PodList.Iterms）去判断 Pod 的副本数是否符合预期，这样行为由于环境的不同，pod 终结快慢等影响，稳定性不可控。
同时尽可能的不采取强制删除 Pod 的方式，避免出现端口冲突而重启的情况，被 CI 日志采集脚本捕获判定失败。